### PR TITLE
[feat] Recruitment Entity 생성

### DIFF
--- a/src/main/java/com/devpass/backend/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/devpass/backend/domain/recruitment/domain/Recruitment.java
@@ -1,0 +1,50 @@
+package com.devpass.backend.domain.recruitment.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Recruitment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recruitment_id")
+    private Long id;
+
+    @Column(name = "company_name", columnDefinition = "TEXT")
+    private String companyName;
+
+    @Column(name = "position")
+    private String position;
+
+    @Column(name = "location")
+    private String location;
+
+    @Column(name = "career")
+    private String career;
+
+    @Column(name = "main_task", columnDefinition = "TEXT")
+    private String mainTask;
+
+    @Column(name = "qualification", columnDefinition = "TEXT")
+    private String qualification;
+
+    @Column(name = "preferred", columnDefinition = "TEXT")
+    private String preferred;
+
+    @Column(name = "benefit", columnDefinition = "TEXT")
+    private String benefit;
+
+    @Column(name = "recruiting", nullable = true, columnDefinition = "TEXT")
+    private String recruiting;
+
+    @Column(name = "deadline")
+    private String deadline;
+}

--- a/src/main/java/com/devpass/backend/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/devpass/backend/domain/recruitment/domain/Recruitment.java
@@ -48,11 +48,11 @@ public class Recruitment {
     @Column(name = "benefit", columnDefinition = "TEXT")
     private String benefit;
 
-    @Column(name = "recruiting", nullable = true, columnDefinition = "TEXT")
-    private String recruiting;
-
     @Column(name = "deadline")
     private String deadline;
+
+    @Column(name = "image_url")
+    private String imageUrl;
 
     @ManyToMany
     @JoinTable(

--- a/src/main/java/com/devpass/backend/domain/recruitment/domain/Recruitment.java
+++ b/src/main/java/com/devpass/backend/domain/recruitment/domain/Recruitment.java
@@ -1,10 +1,16 @@
 package com.devpass.backend.domain.recruitment.domain;
 
+import com.devpass.backend.domain.stack.domain.Stack;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -47,4 +53,12 @@ public class Recruitment {
 
     @Column(name = "deadline")
     private String deadline;
+
+    @ManyToMany
+    @JoinTable(
+        name = "recruitment_stack",
+    joinColumns = @JoinColumn(name = "recruitment_id"),
+    inverseJoinColumns = @JoinColumn(name = "stack_id")
+    )
+    private List<Stack> stacks = new ArrayList<>();
 }

--- a/src/main/java/com/devpass/backend/domain/stack/domain/Stack.java
+++ b/src/main/java/com/devpass/backend/domain/stack/domain/Stack.java
@@ -1,0 +1,28 @@
+package com.devpass.backend.domain.stack.domain;
+
+import com.devpass.backend.domain.recruitment.domain.Recruitment;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Entity
+public class Stack {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "stack_id")
+    private Long id;
+
+    @Column(name = "name", unique = true)
+    private String name;
+
+    @ManyToMany(mappedBy = "stacks")
+    private List<Recruitment> recruitments;
+}


### PR DESCRIPTION
## 📖 개요
https://github.com/DevPass-Inc/backend/issues/3

## 💻 작업사항
- 크롤링 데이터 저장에 필요한 Recruitment Entity 생성
- 기존 String으로는 너무 짧아서 TEXT사용
- recruiting(채용 전형) 필드는 없는 공고도 많아서 nullable 처리

## 💡 작성한 이슈 외에 작업한 사항
- X

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
