### PR TITLE
[feat] 이력서 기반 기업 매칭 API 구현

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM bellsoft/liberica-openjdk-debian:17 AS builder
+WORKDIR /builder
+
+COPY ./gradlew /builder/gradlew
+COPY ./gradle /builder/gradle
+RUN chmod +x ./gradlew
+
+COPY ./ /builder/
+
+RUN ./gradlew clean build -x test
+
+FROM bellsoft/liberica-openjre-debian:17-cds
+WORKDIR /application
+
+ARG JAR_FILE=build/libs/*.jar
+COPY --from=builder /builder/${JAR_FILE} application.jar
+
+ENTRYPOINT ["java", "-jar", "application.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     //implementation 'org.springframework.boot:spring-boot-starter-web-services'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,20 @@
 services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    restart: always
+    env_file:
+      - .env
+    environment:
+      SPRING_DATASOURCE_URL: ${DB_URL}
+      SPRING_DATASOURCE_USERNAME: ${DB_USERNAME}
+      SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD}
+    depends_on:
+      db:
+        condition: service_healthy
   db:
     image: mysql/mysql-server:8.0
     container_name: devpass-db
@@ -17,12 +33,15 @@ services:
     volumes:
       - db_vol:/var/lib/mysql
     healthcheck:
-      test: [ "CMD-SHELL", "mysqladmin ping -h localhost -u root --password=password || exit 1" ]
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "--password=${DB_ROOT_PASSWORD}" ]
       interval: 10s
       timeout: 5s
       retries: 5
-      start_period: 30s
 
 volumes:
   db_vol:
     driver: local
+
+networks:
+  default:
+    name: devpass-network

--- a/src/main/java/com/devpass/backend/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/devpass/backend/domain/recruitment/controller/RecruitmentController.java
@@ -1,0 +1,32 @@
+package com.devpass.backend.domain.recruitment.controller;
+
+import com.devpass.backend.domain.recruitment.dto.request.RecommendRecruitRequest;
+import com.devpass.backend.domain.recruitment.dto.response.RecommendRecruitResponse;
+import com.devpass.backend.domain.recruitment.service.RecruitmentService;
+import com.devpass.backend.global.common.response.CustomResponse;
+import com.devpass.backend.global.result.ResultCode;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/recruitments")
+public class RecruitmentController {
+
+    private final RecruitmentService recruitmentService;
+
+    @Operation(summary = "AI 기업 매칭", description = "AI 기업 매칭 조회")
+    @PostMapping("/ai")
+    public Mono<CustomResponse<List<RecommendRecruitResponse>>> getRecommendRecruit(
+        @RequestBody RecommendRecruitRequest request) {
+
+        return recruitmentService.getRecommendRecruit(request)
+            .map(recommendations -> CustomResponse.of(ResultCode.OK, recommendations));
+    }
+}

--- a/src/main/java/com/devpass/backend/domain/recruitment/dto/request/RecommendRecruitRequest.java
+++ b/src/main/java/com/devpass/backend/domain/recruitment/dto/request/RecommendRecruitRequest.java
@@ -1,0 +1,14 @@
+package com.devpass.backend.domain.recruitment.dto.request;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecommendRecruitRequest {
+    private List<String> userStacks;
+    private String userResume;
+}

--- a/src/main/java/com/devpass/backend/domain/recruitment/dto/response/RecommendRecruitResponse.java
+++ b/src/main/java/com/devpass/backend/domain/recruitment/dto/response/RecommendRecruitResponse.java
@@ -1,0 +1,18 @@
+package com.devpass.backend.domain.recruitment.dto.response;
+
+import com.devpass.backend.domain.stack.dto.response.StackStatusResponse;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RecommendRecruitResponse {
+
+    private String companyName;
+    private String position;
+    private String finalScore;
+    private List<StackStatusResponse> stacks;
+}

--- a/src/main/java/com/devpass/backend/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/devpass/backend/domain/recruitment/service/RecruitmentService.java
@@ -1,0 +1,25 @@
+package com.devpass.backend.domain.recruitment.service;
+
+import com.devpass.backend.domain.recruitment.dto.request.RecommendRecruitRequest;
+import com.devpass.backend.domain.recruitment.dto.response.RecommendRecruitResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class RecruitmentService {
+
+    private final WebClient webClient;
+
+    public Mono<List<RecommendRecruitResponse>> getRecommendRecruit(RecommendRecruitRequest request) {
+        return webClient.post()
+            .uri("/recommend")
+            .bodyValue(request)
+            .retrieve()
+            .bodyToMono(new ParameterizedTypeReference<List<RecommendRecruitResponse>>() {});
+    }
+}

--- a/src/main/java/com/devpass/backend/domain/stack/dto/response/StackStatusResponse.java
+++ b/src/main/java/com/devpass/backend/domain/stack/dto/response/StackStatusResponse.java
@@ -1,0 +1,13 @@
+package com.devpass.backend.domain.stack.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StackStatusResponse {
+    private String stack;
+    private boolean isRequired;
+}

--- a/src/main/java/com/devpass/backend/global/config/WebClientConfig.java
+++ b/src/main/java/com/devpass/backend/global/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package com.devpass.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient(WebClient.Builder builder) {
+        return builder.baseUrl("http://localhost:8000").build();
+    }
+}


### PR DESCRIPTION
## 📖 개요
- 이력서 기반 기업 매칭 API 구현
<img width="424" alt="image" src="https://github.com/user-attachments/assets/82982991-829a-4404-8608-c1b47f9a55c9" />
<img width="337" alt="image" src="https://github.com/user-attachments/assets/b9b47c54-7d18-414c-b0a8-439444255020" />


## 💻 작업사항
- FastAPI 서버와 연결을 위한 WebFlux 설정
- Spring WebFlux에서 단일 값을 비동기적으로 처리하기 위해 Mono 사용 (아래 이유로 사용)
  - Mono를 사용한 이유
    - 요청마다 스레드 블로킹 발생
    - 동시성 처리하기 어려움
    - 외부 API와 연결하기 위해

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
