### PR TITLE
[chore] ElasticSearch 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
     implementation 'io.netty:netty-resolver-dns-native-macos:4.1.109.Final:osx-aarch_64'
+
+    // elasticsearch
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,11 +51,24 @@ services:
     networks:
       - default
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
+    ports:
+      - '9200:9200'
+    environment:
+      - discovery.type=single-node
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - xpack.security.enabled=false
+      - xpack.security.transport.ssl.enabled=false
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
 
 volumes:
   db_vol:
     driver: local
   mongo_data:
+    driver: local
+  esdata:
     driver: local
 
 networks:

--- a/src/main/java/com/devpass/backend/BackendApplication.java
+++ b/src/main/java/com/devpass/backend/BackendApplication.java
@@ -17,6 +17,9 @@ public class BackendApplication {
         System.setProperty("DB_PASSWORD", dotenv.get("DB_PASSWORD"));
         System.setProperty("DB_URL", dotenv.get("DB_URL"));
         System.setProperty("MONGODB_URI", dotenv.get("MONGODB_URI"));
+        System.setProperty("ELASTICSEARCH_USERNAME", dotenv.get("ELASTICSEARCH_USERNAME"));
+        System.setProperty("ELASTICSEARCH_PASSWORD", dotenv.get("ELASTICSEARCH_PASSWORD"));
+        System.setProperty("ELASTICSEARCH_URL", dotenv.get("ELASTICSEARCH_URL"));
 
         SpringApplication.run(BackendApplication.class, args);
     }

--- a/src/main/java/com/devpass/backend/global/config/ElasticsearchConfig.java
+++ b/src/main/java/com/devpass/backend/global/config/ElasticsearchConfig.java
@@ -1,0 +1,26 @@
+package com.devpass.backend.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+
+@Configuration
+public class ElasticsearchConfig extends ElasticsearchConfiguration {
+    @Value("${spring.elasticsearch.username}")
+    private String username;
+
+    @Value("${spring.elasticsearch.password}")
+    private String password;
+
+    @Value("${spring.elasticsearch.uris}")
+    private String elasticUrl;
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+            .connectedTo(elasticUrl)
+            .withBasicAuth(username, password)
+            .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,11 @@ spring:
     mongodb:
       uri: ${MONGODB_URI}
 
+  elasticsearch:
+    username: ${ELASTICSEARCH_USERNAME}
+    password: ${ELASTICSEARCH_PASSWORD}
+    uris: ${ELASTICSEARCH_URL}
+
   jpa:
     hibernate:
       ddl-auto: update


### PR DESCRIPTION
## 📖 개요
- ElasticSearch 세팅

## 💻 작업사항
- docker-compose에 Elasticsearch 추가 (version: 8.11.1)
  - Elasticsearch 8버전 이상부터는 인증이 필수로 바뀌어서 username, password를 넣어줘야한다고 합니다. ([Elasticsearch8 Security](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-minimal-setup.html))
  - 하지만 원활하고 빠른 개발을 위해 일단 `xpack.security.enabled=false` 옵션을 사용하여 username과 password 없이도 접근 가능하도록 해두었습니다.
    - 추후 개발이 완료되면 삭제할 예정입니다.

## 💡 작성한 이슈 외에 작업한 사항
- x

## ✔️ check list

- [ ] 작성한 이슈의 내용을 전부 적용했나요?
- [ ] 리뷰어를 등록했나요?
