### PR TITLE
[fix] 이력서 도메인 API 개발로 인한 AI 기업 매칭 기능 수정

### DIFF
--- a/src/main/java/com/devpass/domain/recruitment/dto/request/RecommendRecruitRequestDTO.java
+++ b/src/main/java/com/devpass/domain/recruitment/dto/request/RecommendRecruitRequestDTO.java
@@ -11,5 +11,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class RecommendRecruitRequestDTO {
     @JsonProperty("resume_id")
-    private Long resumeId;
+    private String resumeId;
 }

--- a/src/main/java/com/devpass/domain/recruitment/dto/request/RecommendRecruitRequestDTO.java
+++ b/src/main/java/com/devpass/domain/recruitment/dto/request/RecommendRecruitRequestDTO.java
@@ -10,9 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RecommendRecruitRequestDTO {
-    @JsonProperty("user_stacks")
-    private List<String> userStacks;
-
-    @JsonProperty("user_resume")
-    private String userResume;
+    @JsonProperty("resume_id")
+    private Long resumeId;
 }

--- a/src/main/java/com/devpass/domain/recruitment/infrastructure/RecruitmentRecommendationWebClient.java
+++ b/src/main/java/com/devpass/domain/recruitment/infrastructure/RecruitmentRecommendationWebClient.java
@@ -3,8 +3,14 @@ package com.devpass.domain.recruitment.infrastructure;
 import com.devpass.domain.recruitment.dto.request.RecommendRecruitRequestDTO;
 import com.devpass.domain.recruitment.dto.response.RecommendRecruitResponseDTO;
 
+import com.devpass.global.payload.apicode.ErrorCode;
+import com.devpass.global.payload.error.exception.GeneralException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.api.ErrorMessage;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -15,6 +21,7 @@ import reactor.core.publisher.Mono;
 public class RecruitmentRecommendationWebClient implements RecruitmentRecommendationClient {
 
     private final WebClient webClient;
+    private final ObjectMapper objectMapper;
 
     @Override
     public Mono<List<RecommendRecruitResponseDTO>> getRecommendRecruit(
@@ -23,6 +30,18 @@ public class RecruitmentRecommendationWebClient implements RecruitmentRecommenda
             .uri("/recommend")
             .bodyValue(request)
             .retrieve()
-            .bodyToMono(new ParameterizedTypeReference<List<RecommendRecruitResponseDTO>>() {});
+            .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {
+            })
+            .map(response -> {
+                Object data = response.get("data");
+                if (data instanceof List<?> list) {
+                    return list.stream()
+                        .map(item -> objectMapper.convertValue(item,
+                            RecommendRecruitResponseDTO.class))
+                        .collect(Collectors.toList());
+                } else {
+                    throw new GeneralException(ErrorCode.BAD_REQUEST);
+                }
+            });
     }
 }


### PR DESCRIPTION
## 📖 개요
- 이력서 도메인 API 개발로 인한 AI 기업 매칭 수정

## 💻 작업사항
- https://github.com/DevPass-Inc/AI-Server/pull/12 로 인해 resumeId만 request받도록 수정
- 파이썬 서버에서 받는 response의 data 값만 추출해서 리턴하도록 수정

## 💡 작성한 이슈 외에 작업한 사항
- x

## ✔️ check list
- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
