### PR TITLE
[refactor] Swagger 문서에서 @AuthUser 파라미터 제거 처리

### DIFF
--- a/src/main/java/com/devpass/global/config/SwaggerConfig.java
+++ b/src/main/java/com/devpass/global/config/SwaggerConfig.java
@@ -15,6 +15,9 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 
 @Configuration
 public class SwaggerConfig {
+    static {
+        SpringDocUtils.getConfig().addAnnotationsToIgnore(AuthUser.class);
+    }
 
     @Bean
     public OpenAPI openAPI() {

--- a/src/main/java/com/devpass/global/config/SwaggerConfig.java
+++ b/src/main/java/com/devpass/global/config/SwaggerConfig.java
@@ -1,35 +1,32 @@
 package com.devpass.global.config;
 
-import io.swagger.v3.oas.models.Components;
-
 import org.springdoc.core.utils.SpringDocUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.devpass.global.annotation.AuthUser;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
 
 @Configuration
 public class SwaggerConfig {
-    static {
-        SpringDocUtils.getConfig().addAnnotationsToIgnore(AuthUser.class);
-    }
+	static {
+		SpringDocUtils.getConfig().addAnnotationsToIgnore(AuthUser.class);
+	}
 
-    @Bean
-    public OpenAPI openAPI() {
-        return new OpenAPI()
-            .components(new Components())
-            .info(apiInfo());
-    }
+	@Bean
+	public OpenAPI openAPI() {
+		return new OpenAPI()
+			.components(new Components())
+			.info(apiInfo());
+	}
 
-    private Info apiInfo() {
-        return new Info()
-            .title("Devpass API")
-            .description("Devpass API Docs")
-            .version("1.0");
-    }
+	private Info apiInfo() {
+		return new Info()
+			.title("Devpass API")
+			.description("Devpass API Docs")
+			.version("1.0");
+	}
 }


### PR DESCRIPTION
## 📖 개요
Swagger 문서에서 `@AuthUser` 파라미터 제거 처리

## 💻 작업사항

- Swagger에서 `@AuthUser` 파라미터를 제외 처리하여, 불필요한 `userId` 입력 없이 Swagger 테스트 가능하도록 개선했습니다.

## 💡 작성한 이슈 외에 작업한 사항

- 없습니다.

## ✔️ check list

- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
