### PR TITLE
[feat] 채용 공고 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/devpass/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/devpass/domain/recruitment/controller/RecruitmentController.java
@@ -34,9 +34,9 @@ public class RecruitmentController {
 
 	@Operation(summary = "채용공고 리스트 조회", description = "채용공고 리스트를 페이지네이션으로 조회합니다.")
 	@GetMapping
-	public ApiResponse<Page<RecruitmentCardResponseDTO>> getRecruitmentList(PageRequestDTO pageRequestDTO) {
+	public ApiResponse<Page<RecruitmentCardResponseDTO>> getRecruitments(PageRequestDTO pageRequestDTO) {
 		Pageable pageable = pageRequestDTO.of();
-		Page<RecruitmentCardResponseDTO> responseDTOs = recruitmentService.getRecruitmentCards(pageable);
-		return ApiResponse.of(SuccessCode.OK, responseDTOs);
+		Page<RecruitmentCardResponseDTO> recruitmentCards = recruitmentService.getRecruitmentCards(pageable);
+		return ApiResponse.of(SuccessCode.OK, recruitmentCards);
 	}
 }

--- a/src/main/java/com/devpass/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/devpass/domain/recruitment/controller/RecruitmentController.java
@@ -1,5 +1,9 @@
 package com.devpass.domain.recruitment.controller;
 
+import com.devpass.domain.recruitment.dto.response.RecruitmentCardResponseDTO;
+import com.devpass.global.common.dto.PageRequestDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,5 +30,13 @@ public class RecruitmentController {
 		RecruitmentDetailResponseDTO responseDTO = recruitmentService.getRecruitmentById(recruitmentId);
 
 		return ApiResponse.of(SuccessCode.OK, responseDTO);
+	}
+
+	@Operation(summary = "채용공고 리스트 조회", description = "채용공고 리스트를 페이지네이션으로 조회합니다.")
+	@GetMapping
+	public ApiResponse<Page<RecruitmentCardResponseDTO>> getRecruitmentList(PageRequestDTO pageRequestDTO) {
+		Pageable pageable = pageRequestDTO.of();
+		Page<RecruitmentCardResponseDTO> responseDTOs = recruitmentService.getRecruitmentCards(pageable);
+		return ApiResponse.of(SuccessCode.OK, responseDTOs);
 	}
 }

--- a/src/main/java/com/devpass/domain/recruitment/converter/RecruitmentConverter.java
+++ b/src/main/java/com/devpass/domain/recruitment/converter/RecruitmentConverter.java
@@ -1,7 +1,11 @@
 package com.devpass.domain.recruitment.converter;
 
+import com.devpass.domain.recruitment.dto.response.RecruitmentCardResponseDTO;
 import com.devpass.domain.recruitment.dto.response.RecruitmentDetailResponseDTO;
 import com.devpass.domain.recruitment.entity.Recruitment;
+import com.devpass.domain.stack.entity.Stack;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class RecruitmentConverter {
 
@@ -18,6 +22,22 @@ public class RecruitmentConverter {
             .benefit(recruitment.getBenefit())
             .deadline(recruitment.getDeadline())
             .imageUrl(recruitment.getImageUrl())
+            .build();
+    }
+
+    public static RecruitmentCardResponseDTO toRecruitmentCardResponse(Recruitment recruitment) {
+        List<String> stackNames = recruitment.getStacks().stream()
+            .map(Stack::getName)
+            .collect(Collectors.toList());
+
+        return RecruitmentCardResponseDTO.builder()
+            .id(recruitment.getId())
+            .imageUrl(recruitment.getImageUrl())
+            .companyName(recruitment.getCompanyName())
+            .position(recruitment.getPosition())
+            .career(recruitment.getCareer())
+            .location(recruitment.getLocation())
+            .stacks(stackNames)
             .build();
     }
 }

--- a/src/main/java/com/devpass/domain/recruitment/dto/response/RecruitmentCardResponseDTO.java
+++ b/src/main/java/com/devpass/domain/recruitment/dto/response/RecruitmentCardResponseDTO.java
@@ -1,0 +1,21 @@
+package com.devpass.domain.recruitment.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecruitmentCardResponseDTO {
+    private Long id;
+    private String imageUrl;
+    private String companyName;
+    private String position;
+    private String career;
+    private String location;
+    private List<String> stacks;
+}

--- a/src/main/java/com/devpass/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/devpass/domain/recruitment/repository/RecruitmentRepository.java
@@ -1,7 +1,10 @@
 package com.devpass.domain.recruitment.repository;
 
 import com.devpass.domain.recruitment.entity.Recruitment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
+    Page<Recruitment> findAll(Pageable pageable);
 }

--- a/src/main/java/com/devpass/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/devpass/domain/recruitment/service/RecruitmentService.java
@@ -1,11 +1,16 @@
 package com.devpass.domain.recruitment.service;
 
 import com.devpass.domain.recruitment.converter.RecruitmentConverter;
+import com.devpass.domain.recruitment.dto.response.RecruitmentCardResponseDTO;
 import com.devpass.domain.recruitment.dto.response.RecruitmentDetailResponseDTO;
 import com.devpass.domain.recruitment.entity.Recruitment;
 import com.devpass.domain.recruitment.exception.RecruitmentNotFoundException;
 import com.devpass.domain.recruitment.repository.RecruitmentRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,5 +26,12 @@ public class RecruitmentService {
             .orElseThrow(RecruitmentNotFoundException::new);
 
         return RecruitmentConverter.toRecruitmentDetailResponse(recruitment);
+    }
+
+    // 채용 공고 리스트 조회
+    @Transactional(readOnly = true)
+    public Page<RecruitmentCardResponseDTO> getRecruitmentCards(Pageable pageable) {
+        Page<Recruitment> recruitments = recruitmentRepository.findAll(pageable);
+        return recruitments.map(RecruitmentConverter::toRecruitmentCardResponse);
     }
 }

--- a/src/main/java/com/devpass/global/common/dto/PageRequestDTO.java
+++ b/src/main/java/com/devpass/global/common/dto/PageRequestDTO.java
@@ -1,0 +1,36 @@
+package com.devpass.global.common.dto;
+
+import com.devpass.global.payload.apicode.ErrorStatus;
+import com.devpass.global.payload.error.exception.GeneralException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+
+public class PageRequestDTO {
+    private static final int DEFAULT_SIZE = 8;
+    private static final int MAX_SIZE = 50;
+
+    private int page = 1;
+    private int size = 8;
+    private Sort.Direction direction = Direction.DESC;
+
+    public void setPage(int page) {
+        this.page = page <= 0 ? 1 : page;
+    }
+
+    public void setSize(int size) {
+        this.size = size > MAX_SIZE ? DEFAULT_SIZE : size;
+    }
+
+    public void setDirection(Sort.Direction direction) {
+        this.direction = direction;
+    }
+
+    public PageRequest of() {
+        if (size <= 0) {
+            throw new GeneralException(ErrorStatus.BAD_REQUEST);
+        }
+        return PageRequest.of(page - 1, size, direction, "createdAt");
+    }
+
+}


### PR DESCRIPTION
## 📖 개요
- 채용공고 리스트 조회 API

## 💻 작업사항
- 채용공고 리스트 조회 API 구현
- Pagable 객체를 생성할 PageRequestDTO 생성
  - 사용 이유
    - 사용하지 않게되면 Controller에서 @RequestParams로 하나하나 다 관리해야함
    - DTO 안에서 기본값 처리
    - 필터링이 추가 될 경우 변경이 용이하게 하기 위함

## 💡 작성한 이슈 외에 작업한 사항
- x

## ✔️ check list
- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
