### PR TITLE
[feat] 채용 공고 검색 API에 연봉, 직원 수 필터링 추가

### DIFF
--- a/src/main/java/com/devpass/domain/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/devpass/domain/recruitment/controller/RecruitmentController.java
@@ -1,9 +1,5 @@
 package com.devpass.domain.recruitment.controller;
 
-import com.devpass.domain.recruitment.dto.response.RecruitmentCardResponseDTO;
-import com.devpass.global.common.dto.PageRequestDTO;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,13 +26,5 @@ public class RecruitmentController {
 		RecruitmentDetailResponseDTO responseDTO = recruitmentService.getRecruitmentById(recruitmentId);
 
 		return ApiResponse.of(SuccessCode.OK, responseDTO);
-	}
-
-	@Operation(summary = "채용공고 리스트 조회", description = "채용공고 리스트를 페이지네이션으로 조회합니다.")
-	@GetMapping
-	public ApiResponse<Page<RecruitmentCardResponseDTO>> getRecruitments(PageRequestDTO pageRequestDTO) {
-		Pageable pageable = pageRequestDTO.of();
-		Page<RecruitmentCardResponseDTO> recruitmentCards = recruitmentService.getRecruitmentCards(pageable);
-		return ApiResponse.of(SuccessCode.OK, recruitmentCards);
 	}
 }

--- a/src/main/java/com/devpass/domain/recruitment/controller/RecruitmentSearchController.java
+++ b/src/main/java/com/devpass/domain/recruitment/controller/RecruitmentSearchController.java
@@ -31,9 +31,14 @@ public class RecruitmentSearchController {
         @RequestParam(required = false) List<Long> stackIds,
         @RequestParam(required = false) String region,
         @RequestParam(required = false) String district,
+        @RequestParam(required = false) Integer minEmployeeCount,
+        @RequestParam(required = false) Integer minNewHireAvgSalary,
         @PageableDefault(sort = "DESC") Pageable pageable)
         throws IOException {
-        Page<RecruitmentDocument> recruitments = recruitmentSearchService.searchByName(keyword, position, minCareer, stackIds, region, district, pageable);
+        Page<RecruitmentDocument> recruitments = recruitmentSearchService.searchByName(
+            keyword, position, minCareer, stackIds, region, district,
+            minEmployeeCount, minNewHireAvgSalary, pageable
+        );
         return ApiResponse.of(SuccessCode.OK, recruitments);
     }
 }

--- a/src/main/java/com/devpass/domain/recruitment/document/RecruitmentDocument.java
+++ b/src/main/java/com/devpass/domain/recruitment/document/RecruitmentDocument.java
@@ -13,7 +13,14 @@ import org.springframework.data.elasticsearch.annotations.Document;
 public class RecruitmentDocument {
     @Id
     private String id;
+
+    // 기업 정보
+    private Long companyId;
     private String companyName;
+    private String employeeCount;
+    private Integer newHireAvgSalary;
+
+    // 채용공고 정보
     private String positionName;
     private String position;
     private Location location;
@@ -29,14 +36,20 @@ public class RecruitmentDocument {
     private List<Long> stacks;
 
     @Builder
-    public RecruitmentDocument(String id, String companyName, String positionName, String position, Location location, String career,
+    public RecruitmentDocument(String id, Long companyId, String companyName,
+        String employeeCount, Integer newHireAvgSalary,
+        String positionName, String position, Location location, String career,
         String mainTask, String qualification, String preferred, String benefit,
         String deadline, String imageUrl,
         Integer minCareer, Integer maxCareer,
-        List<Long> stacks)
-    {
+        List<Long> stacks) {
+
         this.id = id;
+        this.companyId = companyId;
         this.companyName = companyName;
+        this.employeeCount = employeeCount;
+        this.newHireAvgSalary = newHireAvgSalary;
+
         this.positionName = positionName;
         this.position = position;
         this.location = location;

--- a/src/main/java/com/devpass/domain/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/devpass/domain/recruitment/repository/RecruitmentRepository.java
@@ -1,10 +1,6 @@
 package com.devpass.domain.recruitment.repository;
 
 import com.devpass.domain.recruitment.entity.Recruitment;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
-    Page<Recruitment> findAll(Pageable pageable);
-}
+public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> { }

--- a/src/main/java/com/devpass/domain/recruitment/service/RecruitmentSearchService.java
+++ b/src/main/java/com/devpass/domain/recruitment/service/RecruitmentSearchService.java
@@ -30,6 +30,8 @@ public class RecruitmentSearchService {
         List<Long> stackIds,
         String region,
         String district,
+        Integer minEmployeeCount,
+        Integer minNewHireAvgSalary,
         Pageable pageable
     ) throws IOException {
 
@@ -84,6 +86,20 @@ public class RecruitmentSearchService {
 
                         if (district != null && !district.isBlank()) {
                             filters.add(Query.of(f -> f.term(t -> t.field("location.district").value(district))));
+                        }
+
+                        if (minEmployeeCount != null) {
+                            filters.add(Query.of(f -> f.range(r -> r
+                                .field("employeeCount")
+                                .gte(JsonData.of(minEmployeeCount))
+                            )));
+                        }
+
+                        if (minNewHireAvgSalary != null) {
+                            filters.add(Query.of(f -> f.range(r -> r
+                                .field("newHireAvgSalary")
+                                .gte(JsonData.of(minNewHireAvgSalary))
+                            )));
                         }
 
                         b.filter(filters);

--- a/src/main/java/com/devpass/domain/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/devpass/domain/recruitment/service/RecruitmentService.java
@@ -1,16 +1,11 @@
 package com.devpass.domain.recruitment.service;
 
 import com.devpass.domain.recruitment.converter.RecruitmentConverter;
-import com.devpass.domain.recruitment.dto.response.RecruitmentCardResponseDTO;
 import com.devpass.domain.recruitment.dto.response.RecruitmentDetailResponseDTO;
 import com.devpass.domain.recruitment.entity.Recruitment;
 import com.devpass.domain.recruitment.exception.RecruitmentNotFoundException;
 import com.devpass.domain.recruitment.repository.RecruitmentRepository;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,12 +21,5 @@ public class RecruitmentService {
             .orElseThrow(RecruitmentNotFoundException::new);
 
         return RecruitmentConverter.toRecruitmentDetailResponse(recruitment);
-    }
-
-    // 채용 공고 리스트 조회
-    @Transactional(readOnly = true)
-    public Page<RecruitmentCardResponseDTO> getRecruitmentCards(Pageable pageable) {
-        Page<Recruitment> recruitments = recruitmentRepository.findAll(pageable);
-        return recruitments.map(RecruitmentConverter::toRecruitmentCardResponse);
     }
 }


### PR DESCRIPTION
## 📖 개요
- 채용 공고 검색 API에 연봉, 직원 수 필터링 추가

## 💻 작업사항
- 직원 수 필터링 추가
- 연봉 필터링 추가
- 임시 구현해뒀던 채용공고 목록 조회 API 삭제

## 💡 작성한 이슈 외에 작업한 사항
- x

## ✔️ check list
- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
