### PR TITLE
[refactor] 인턴십, 기술스택 도메인 API 리팩토링

### DIFF
--- a/src/main/java/com/devpass/domain/devexperience/dto/response/DevExperienceAggregateResponseDTO.java
+++ b/src/main/java/com/devpass/domain/devexperience/dto/response/DevExperienceAggregateResponseDTO.java
@@ -2,7 +2,7 @@ package com.devpass.domain.devexperience.dto.response;
 
 import com.devpass.domain.internship.dto.response.InternshipResponseDTO;
 import com.devpass.domain.project.dto.response.ProjectResponseDTO;
-import com.devpass.domain.stack.dto.response.StackStatusResponseDTO;
+import com.devpass.domain.stack.dto.response.StackResponseDTO;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,5 +15,5 @@ public class DevExperienceAggregateResponseDTO {
     private DevExperienceResponseDTO devExperience;
     private List<ProjectResponseDTO> projects;
     private List<InternshipResponseDTO> internships;
-    private List<StackStatusResponseDTO> stacks;
+    private List<StackResponseDTO> stacks;
 }

--- a/src/main/java/com/devpass/domain/devexperience/entity/DevExperience.java
+++ b/src/main/java/com/devpass/domain/devexperience/entity/DevExperience.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
-@Table(name = "dev-experiences")
+@Table(name = "dev_experiences")
 public class DevExperience extends BaseEntity {
 
 	@Id

--- a/src/main/java/com/devpass/domain/devexperience/service/DevExperienceAggregateService.java
+++ b/src/main/java/com/devpass/domain/devexperience/service/DevExperienceAggregateService.java
@@ -1,5 +1,6 @@
 package com.devpass.domain.devexperience.service;
 
+import com.devpass.domain.devexpstack.service.DevExpStackService;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -12,7 +13,6 @@ import com.devpass.domain.internship.service.InternshipService;
 import com.devpass.domain.project.dto.response.ProjectResponseDTO;
 import com.devpass.domain.project.service.ProjectService;
 import com.devpass.domain.stack.dto.response.StackStatusResponseDTO;
-import com.devpass.domain.stack.service.StackService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,7 +23,7 @@ public class DevExperienceAggregateService {
 	private final DevExperienceService devExperienceService;
 	private final ProjectService projectService;
 	private final InternshipService internshipService;
-	private final StackService stackService;
+	private final DevExpStackService devExpStackService;
 
 	@Transactional(readOnly = true)
 	public DevExperienceAggregateResponseDTO getAggregateByDevExperienceId(Long userId, Long devExperienceId) {
@@ -31,7 +31,7 @@ public class DevExperienceAggregateService {
 		List<ProjectResponseDTO> projects = projectService.getProjectsByDevExperienceId(userId, devExperienceId);
 		List<InternshipResponseDTO> internships = internshipService.getInternshipsByDevExperienceId(userId,
 			devExperienceId);
-		List<StackStatusResponseDTO> stacks = stackService.getStacksByDevExperienceId(userId, devExperienceId);
+		List<StackStatusResponseDTO> stacks = devExpStackService.getStacksByDevExperienceId(userId, devExperienceId);
 		return new DevExperienceAggregateResponseDTO(devExperience, projects, internships, stacks);
 	}
 }

--- a/src/main/java/com/devpass/domain/devexperience/service/DevExperienceAggregateService.java
+++ b/src/main/java/com/devpass/domain/devexperience/service/DevExperienceAggregateService.java
@@ -12,7 +12,7 @@ import com.devpass.domain.internship.dto.response.InternshipResponseDTO;
 import com.devpass.domain.internship.service.InternshipService;
 import com.devpass.domain.project.dto.response.ProjectResponseDTO;
 import com.devpass.domain.project.service.ProjectService;
-import com.devpass.domain.stack.dto.response.StackStatusResponseDTO;
+import com.devpass.domain.stack.dto.response.StackResponseDTO;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,7 +31,7 @@ public class DevExperienceAggregateService {
 		List<ProjectResponseDTO> projects = projectService.getProjectsByDevExperienceId(userId, devExperienceId);
 		List<InternshipResponseDTO> internships = internshipService.getInternshipsByDevExperienceId(userId,
 			devExperienceId);
-		List<StackStatusResponseDTO> stacks = devExpStackService.getStacksByDevExperienceId(userId, devExperienceId);
+		List<StackResponseDTO> stacks = devExpStackService.getStacksByDevExperienceId(userId, devExperienceId);
 		return new DevExperienceAggregateResponseDTO(devExperience, projects, internships, stacks);
 	}
 }

--- a/src/main/java/com/devpass/domain/devexpstack/controller/DevExpStackController.java
+++ b/src/main/java/com/devpass/domain/devexpstack/controller/DevExpStackController.java
@@ -4,7 +4,7 @@ import com.devpass.domain.devexpstack.service.DevExpStackService;
 import com.devpass.domain.stack.converter.StackConverter;
 import com.devpass.domain.stack.dto.request.StackAddRequestDTO;
 import com.devpass.domain.stack.dto.response.StackListResponseDTO;
-import com.devpass.domain.stack.dto.response.StackStatusResponseDTO;
+import com.devpass.domain.stack.dto.response.StackResponseDTO;
 import com.devpass.domain.stack.entity.Stack;
 import com.devpass.global.annotation.AuthUser;
 import com.devpass.global.payload.ApiResponse;
@@ -36,7 +36,7 @@ public class DevExpStackController {
         @PathVariable("devExperienceId") Long devExperienceId,
         @RequestBody StackAddRequestDTO request) {
         List<Stack> stacks = devExpStackService.addStacksToDevExperience(userId, devExperienceId, request);
-        List<StackStatusResponseDTO> stackDTOs = StackConverter.toStatusResponseDTOList(stacks);
+        List<StackResponseDTO> stackDTOs = StackConverter.toResponseDTOList(stacks);
         StackListResponseDTO responseDTO = new StackListResponseDTO(stackDTOs);
         return ApiResponse.of(SuccessCode.CREATED, responseDTO);
     }
@@ -47,7 +47,7 @@ public class DevExpStackController {
         @PathVariable("devExperienceId") Long devExperienceId,
         @RequestBody StackAddRequestDTO request) {
         List<Stack> updatedStacks = devExpStackService.updateStacksToDevExperience(devExperienceId, request);
-        List<StackStatusResponseDTO> stackDTOs = StackConverter.toStatusResponseDTOList(updatedStacks);
+        List<StackResponseDTO> stackDTOs = StackConverter.toResponseDTOList(updatedStacks);
         StackListResponseDTO responseDTO = new StackListResponseDTO(stackDTOs);
         return ApiResponse.of(SuccessCode.OK, responseDTO);
     }
@@ -67,7 +67,7 @@ public class DevExpStackController {
         @AuthUser Long userId,
         @PathVariable("devExperienceId") Long devExperienceId) {
 
-        List<StackStatusResponseDTO> stackDTOs = devExpStackService.getStacksByDevExperienceId(userId, devExperienceId);
+        List<StackResponseDTO> stackDTOs = devExpStackService.getStacksByDevExperienceId(userId, devExperienceId);
         StackListResponseDTO responseDTO = new StackListResponseDTO(stackDTOs);
         return ApiResponse.of(SuccessCode.OK, responseDTO);
     }

--- a/src/main/java/com/devpass/domain/devexpstack/controller/DevExpStackController.java
+++ b/src/main/java/com/devpass/domain/devexpstack/controller/DevExpStackController.java
@@ -1,0 +1,74 @@
+package com.devpass.domain.devexpstack.controller;
+
+import com.devpass.domain.devexpstack.service.DevExpStackService;
+import com.devpass.domain.stack.converter.StackConverter;
+import com.devpass.domain.stack.dto.request.StackAddRequestDTO;
+import com.devpass.domain.stack.dto.response.StackListResponseDTO;
+import com.devpass.domain.stack.dto.response.StackStatusResponseDTO;
+import com.devpass.domain.stack.entity.Stack;
+import com.devpass.global.annotation.AuthUser;
+import com.devpass.global.payload.ApiResponse;
+import com.devpass.global.payload.apicode.SuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/developments/stacks")
+@Tag(name = "개발경험-기술스택 API")
+public class DevExpStackController {
+    private final DevExpStackService devExpStackService;
+
+    @Operation(summary = "개발경험에 기술스택 추가")
+    @PostMapping("/{devExperienceId}")
+    public ApiResponse<StackListResponseDTO> addStacks(
+        @AuthUser Long userId,
+        @PathVariable("devExperienceId") Long devExperienceId,
+        @RequestBody StackAddRequestDTO request) {
+        List<Stack> stacks = devExpStackService.addStacksToDevExperience(userId, devExperienceId, request);
+        List<StackStatusResponseDTO> stackDTOs = StackConverter.toStatusResponseDTOList(stacks);
+        StackListResponseDTO responseDTO = new StackListResponseDTO(stackDTOs);
+        return ApiResponse.of(SuccessCode.CREATED, responseDTO);
+    }
+
+    @Operation(summary = "기술스택 수정")
+    @PutMapping("/{devExperienceId}")
+    public ApiResponse<StackListResponseDTO> updateStacks(
+        @PathVariable("devExperienceId") Long devExperienceId,
+        @RequestBody StackAddRequestDTO request) {
+        List<Stack> updatedStacks = devExpStackService.updateStacksToDevExperience(devExperienceId, request);
+        List<StackStatusResponseDTO> stackDTOs = StackConverter.toStatusResponseDTOList(updatedStacks);
+        StackListResponseDTO responseDTO = new StackListResponseDTO(stackDTOs);
+        return ApiResponse.of(SuccessCode.OK, responseDTO);
+    }
+
+    @Operation(summary = "기술스택 삭제")
+    @DeleteMapping("/{devExperienceId}")
+    public ApiResponse<Void> deleteStacksByDevExperienceId(
+        @AuthUser Long userId,
+        @PathVariable("devExperienceId") Long devExperienceId) {
+        devExpStackService.deleteStacksByDevExperienceId(userId, devExperienceId);
+        return ApiResponse.of(SuccessCode.OK);
+    }
+
+    @Operation(summary = "개발경험에 등록된 기술스택 조회")
+    @GetMapping("/{devExperienceId}")
+    public ApiResponse<StackListResponseDTO> getStacksByDevExperienceId(
+        @AuthUser Long userId,
+        @PathVariable("devExperienceId") Long devExperienceId) {
+
+        List<StackStatusResponseDTO> stackDTOs = devExpStackService.getStacksByDevExperienceId(userId, devExperienceId);
+        StackListResponseDTO responseDTO = new StackListResponseDTO(stackDTOs);
+        return ApiResponse.of(SuccessCode.OK, responseDTO);
+    }
+}

--- a/src/main/java/com/devpass/domain/devexpstack/entity/DevExpStack.java
+++ b/src/main/java/com/devpass/domain/devexpstack/entity/DevExpStack.java
@@ -1,5 +1,6 @@
 package com.devpass.domain.devexpstack.entity;
 
+import com.devpass.domain.devexperience.entity.DevExperience;
 import com.devpass.domain.project.entity.Project;
 import com.devpass.domain.stack.entity.Stack;
 import com.devpass.global.common.entity.BaseEntity;
@@ -28,16 +29,16 @@ public class DevExpStack extends BaseEntity {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "project_id", nullable = false)
-	private Project project;
+	@JoinColumn(name = "dev_experience_id", nullable = false)
+	private DevExperience devExperience;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "stack_id", nullable = false)
 	private Stack stack;
 
 	@Builder
-	public DevExpStack(Project project, Stack stack) {
-		this.project = project;
+	public DevExpStack(DevExperience devExperience, Stack stack) {
+		this.devExperience = devExperience;
 		this.stack = stack;
 	}
 }

--- a/src/main/java/com/devpass/domain/devexpstack/repository/DevExpStackRepository.java
+++ b/src/main/java/com/devpass/domain/devexpstack/repository/DevExpStackRepository.java
@@ -1,0 +1,14 @@
+package com.devpass.domain.devexpstack.repository;
+
+import com.devpass.domain.devexpstack.entity.DevExpStack;
+import com.devpass.domain.stack.entity.Stack;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface DevExpStackRepository extends JpaRepository<DevExpStack, Long> {
+    void deleteByDevExperienceId(Long devExperienceId);
+
+    @Query("SELECT d.stack FROM DevExpStack d WHERE d.devExperience.id = :devExperienceId AND d.devExperience.user.id = :userId")
+    List<Stack> findStacksByDevExperienceId(Long userId, Long devExperienceId);
+}

--- a/src/main/java/com/devpass/domain/devexpstack/service/DevExpStackService.java
+++ b/src/main/java/com/devpass/domain/devexpstack/service/DevExpStackService.java
@@ -6,7 +6,7 @@ import com.devpass.domain.devexpstack.entity.DevExpStack;
 import com.devpass.domain.devexpstack.repository.DevExpStackRepository;
 import com.devpass.domain.stack.converter.StackConverter;
 import com.devpass.domain.stack.dto.request.StackAddRequestDTO;
-import com.devpass.domain.stack.dto.response.StackStatusResponseDTO;
+import com.devpass.domain.stack.dto.response.StackResponseDTO;
 import com.devpass.domain.stack.entity.Stack;
 import com.devpass.domain.stack.repository.StackRepository;
 import com.devpass.global.payload.apicode.ErrorStatus;
@@ -67,9 +67,9 @@ public class DevExpStackService {
     }
 
     @Transactional(readOnly = true)
-    public List<StackStatusResponseDTO> getStacksByDevExperienceId(Long userId, Long devExperienceId) {
+    public List<StackResponseDTO> getStacksByDevExperienceId(Long userId, Long devExperienceId) {
         List<Stack> stacks = devExpStackRepository.findStacksByDevExperienceId(userId, devExperienceId);
-        return StackConverter.toStatusResponseDTOList(stacks);
+        return StackConverter.toResponseDTOList(stacks);
     }
 
     @Transactional

--- a/src/main/java/com/devpass/domain/devexpstack/service/DevExpStackService.java
+++ b/src/main/java/com/devpass/domain/devexpstack/service/DevExpStackService.java
@@ -1,0 +1,83 @@
+package com.devpass.domain.devexpstack.service;
+
+import com.devpass.domain.devexperience.entity.DevExperience;
+import com.devpass.domain.devexperience.repository.DevExperienceRepository;
+import com.devpass.domain.devexpstack.entity.DevExpStack;
+import com.devpass.domain.devexpstack.repository.DevExpStackRepository;
+import com.devpass.domain.stack.converter.StackConverter;
+import com.devpass.domain.stack.dto.request.StackAddRequestDTO;
+import com.devpass.domain.stack.dto.response.StackStatusResponseDTO;
+import com.devpass.domain.stack.entity.Stack;
+import com.devpass.domain.stack.repository.StackRepository;
+import com.devpass.global.payload.apicode.ErrorStatus;
+import com.devpass.global.payload.error.exception.GeneralException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DevExpStackService {
+
+    private final DevExperienceRepository devExperienceRepository;
+    private final DevExpStackRepository devExpStackRepository;
+    private final StackRepository stackRepository;
+
+    @Transactional
+    public List<Stack> addStacksToDevExperience(Long userId, Long devExperienceId, StackAddRequestDTO request) {
+        DevExperience devExperience = devExperienceRepository.findByIdAndUserId(devExperienceId,
+                userId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND));
+
+        List<com.devpass.domain.stack.entity.Stack> stacks = stackRepository.findAllById(
+            request.getStackIds());
+
+        List<DevExpStack> devExpStacks = stacks.stream()
+            .map(stack -> DevExpStack.builder()
+                .devExperience(devExperience)
+                .stack(stack)
+                .build())
+            .toList();
+
+        devExpStackRepository.saveAll(devExpStacks);
+
+        return devExpStackRepository.findStacksByDevExperienceId(userId, devExperienceId);
+    }
+
+    @Transactional
+    public List<Stack> updateStacksToDevExperience(Long devExperienceId, StackAddRequestDTO request) {
+        DevExperience devExperience = devExperienceRepository.findById(devExperienceId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND));
+
+        devExpStackRepository.deleteByDevExperienceId(devExperienceId);
+
+        List<Stack> stacks = stackRepository.findAllById(request.getStackIds());
+
+        List<DevExpStack> devExpStacks = stacks.stream()
+            .map(stack -> DevExpStack.builder()
+                .devExperience(devExperience)
+                .stack(stack)
+                .build())
+            .toList();
+
+        devExpStackRepository.saveAll(devExpStacks);
+
+        return stacks;
+    }
+
+    @Transactional(readOnly = true)
+    public List<StackStatusResponseDTO> getStacksByDevExperienceId(Long userId, Long devExperienceId) {
+        List<Stack> stacks = devExpStackRepository.findStacksByDevExperienceId(userId, devExperienceId);
+        return StackConverter.toStatusResponseDTOList(stacks);
+    }
+
+    @Transactional
+    public void deleteStacksByDevExperienceId(Long userId, Long devExperienceId) {
+        List<Stack> stacks = devExpStackRepository.findStacksByDevExperienceId(userId, devExperienceId);
+        if (stacks.isEmpty()) {
+            throw new GeneralException(ErrorStatus.NOT_FOUND);
+        }
+        devExpStackRepository.deleteByDevExperienceId(devExperienceId);
+    }
+}

--- a/src/main/java/com/devpass/domain/internship/controller/InternshipController.java
+++ b/src/main/java/com/devpass/domain/internship/controller/InternshipController.java
@@ -51,9 +51,10 @@ public class InternshipController {
 	@Operation(summary = "인턴십 경험 수정")
 	@PutMapping("/{internshipId}")
 	public ApiResponse<InternshipResponseDTO> updateInternship(
+		@AuthUser Long userId,
 		@PathVariable("internshipId") Long internshipId,
 		@RequestBody InternshipAddRequestDTO request) {
-		InternshipResponseDTO updated = internshipService.updateInternship(internshipId, request);
+		InternshipResponseDTO updated = internshipService.updateInternship(userId, internshipId, request);
 		return ApiResponse.of(SuccessCode.OK, updated);
 	}
 

--- a/src/main/java/com/devpass/domain/internship/controller/InternshipController.java
+++ b/src/main/java/com/devpass/domain/internship/controller/InternshipController.java
@@ -38,10 +38,11 @@ public class InternshipController {
 	}
 
 	@Operation(summary = "인턴십 경험 삭제")
-	@DeleteMapping("/{devExperienceId}")
+	@DeleteMapping("/{internshipId}")
 	public ApiResponse<Void> deleteInternships(
-		@PathVariable("devExperienceId") Long devExperienceId) {
-		internshipService.deleteInternshipsByDevExperienceId(devExperienceId);
+		@AuthUser Long userId,
+		@PathVariable("internshipId") Long internshipId) {
+		internshipService.deleteInternshipById(userId, internshipId);
 		return ApiResponse.of(SuccessCode.OK);
 	}
 

--- a/src/main/java/com/devpass/domain/internship/controller/InternshipController.java
+++ b/src/main/java/com/devpass/domain/internship/controller/InternshipController.java
@@ -1,6 +1,8 @@
 package com.devpass.domain.internship.controller;
 
+import java.util.List;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -53,6 +55,14 @@ public class InternshipController {
 		@RequestBody InternshipAddRequestDTO request) {
 		InternshipResponseDTO updated = internshipService.updateInternship(internshipId, request);
 		return ApiResponse.of(SuccessCode.OK, updated);
+	}
+
+	@Operation(summary = "인턴십 경험 목록 조회")
+	@GetMapping("/{devExperienceId}")
+	public ApiResponse<List<InternshipResponseDTO>> getInternshipsByDevExperienceId(
+		@AuthUser Long userId,
+		@PathVariable("devExperienceId") Long devExperienceId) {
+		return ApiResponse.of(SuccessCode.OK, internshipService.getInternshipsByDevExperienceId(userId, devExperienceId));
 	}
 
 }

--- a/src/main/java/com/devpass/domain/internship/service/InternshipService.java
+++ b/src/main/java/com/devpass/domain/internship/service/InternshipService.java
@@ -56,9 +56,12 @@ public class InternshipService {
 	}
 
 	@Transactional
-	public InternshipResponseDTO updateInternship(Long internshipId, InternshipAddRequestDTO request) {
+	public InternshipResponseDTO updateInternship(Long userId, Long internshipId, InternshipAddRequestDTO request) {
 		Internship internship = internshipRepository.findById(internshipId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND));
+		if (!internship.getDevExperience().getUser().getId().equals(userId)) {
+			throw new GeneralException(ErrorStatus.UNAUTHORIZED);
+		}
 		internship.update(request);
 		return InternshipConverter.toResponse(internship);
 	}

--- a/src/main/java/com/devpass/domain/internship/service/InternshipService.java
+++ b/src/main/java/com/devpass/domain/internship/service/InternshipService.java
@@ -1,6 +1,7 @@
 package com.devpass.domain.internship.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -43,12 +44,15 @@ public class InternshipService {
 	}
 
 	@Transactional
-	public void deleteInternshipsByDevExperienceId(Long devExperienceId) {
-		List<Internship> internships = internshipRepository.findAllByDevExperience_Id(devExperienceId);
-		if (internships.isEmpty()) {
+	public void deleteInternshipById(Long userId, Long internshipId) {
+		Optional<Internship> internship = internshipRepository.findById(internshipId);
+		if (internship.isEmpty()) {
 			throw new GeneralException(ErrorStatus.NOT_FOUND);
 		}
-		internshipRepository.deleteAll(internships);
+		if (!internship.get().getDevExperience().getUser().getId().equals(userId)) {
+			throw new GeneralException(ErrorStatus.UNAUTHORIZED);
+		}
+		internshipRepository.deleteById(internshipId);
 	}
 
 	@Transactional

--- a/src/main/java/com/devpass/domain/project/entity/Project.java
+++ b/src/main/java/com/devpass/domain/project/entity/Project.java
@@ -2,9 +2,13 @@ package com.devpass.domain.project.entity;
 
 import com.devpass.domain.devexperience.entity.DevExperience;
 import com.devpass.domain.project.dto.request.ProjectAddRequestDTO;
+import com.devpass.domain.projectstack.entity.ProjectStack;
+import com.devpass.domain.stack.entity.Stack;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
 
 import com.devpass.global.common.entity.BaseEntity;
@@ -15,6 +19,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -51,6 +57,9 @@ public class Project extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "dev_experience_id", nullable = false)
 	private DevExperience devExperience;
+
+	@OneToMany(mappedBy = "project", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	private List<ProjectStack> projectStacks = new ArrayList<>();
 
 	@Builder
 	public Project(DevExperience devExperience, String title, String introduce, String position, LocalDate startDate, LocalDate endDate,

--- a/src/main/java/com/devpass/domain/projectstack/entity/ProjectStack.java
+++ b/src/main/java/com/devpass/domain/projectstack/entity/ProjectStack.java
@@ -1,0 +1,36 @@
+package com.devpass.domain.projectstack.entity;
+
+import com.devpass.domain.project.entity.Project;
+import com.devpass.domain.stack.entity.Stack;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProjectStack {
+    @Id
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name= "project_id", nullable = false)
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stack_id", nullable = false)
+    private Stack stack;
+
+    @Builder
+    public ProjectStack(Long id, Project project, Stack stack) {
+        this.id = id;
+        this.project = project;
+        this.stack = stack;
+    }
+}

--- a/src/main/java/com/devpass/domain/stack/controller/StackController.java
+++ b/src/main/java/com/devpass/domain/stack/controller/StackController.java
@@ -2,17 +2,11 @@ package com.devpass.domain.stack.controller;
 
 import java.util.List;
 
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.devpass.domain.stack.converter.StackConverter;
-import com.devpass.domain.stack.dto.request.StackAddRequestDTO;
 import com.devpass.domain.stack.dto.response.StackListResponseDTO;
 import com.devpass.domain.stack.dto.response.StackStatusResponseDTO;
 import com.devpass.domain.stack.entity.Stack;
@@ -27,23 +21,11 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/developments/stacks")
+@RequestMapping("/api/stacks")
 @Tag(name = "기술스택 API")
 public class StackController {
 
 	private final StackService stackService;
-
-	@Operation(summary = "기술스택 등록")
-	@PostMapping("/{devExperienceId}")
-	public ApiResponse<StackListResponseDTO> addStacks(
-		@AuthUser Long userId,
-		@PathVariable("devExperienceId") Long devExperienceId,
-		@RequestBody StackAddRequestDTO request) {
-		List<Stack> stacks = stackService.addStacks(userId, devExperienceId, request);
-		List<StackStatusResponseDTO> stackDTOs = StackConverter.toStatusResponseDTOList(stacks);
-		StackListResponseDTO responseDTO = new StackListResponseDTO(stackDTOs);
-		return ApiResponse.of(SuccessCode.CREATED, responseDTO);
-	}
 
 	@Operation(summary = "기술스택 조회")
 	@GetMapping
@@ -53,24 +35,5 @@ public class StackController {
 		List<StackStatusResponseDTO> stackDTOs = StackConverter.toStatusResponseDTOList(stacks);
 		StackListResponseDTO responseDTO = new StackListResponseDTO(stackDTOs);
 		return ApiResponse.of(SuccessCode.OK, responseDTO);
-	}
-
-	@Operation(summary = "기술스택 수정")
-	@PutMapping("/{devExperienceId}")
-	public ApiResponse<StackListResponseDTO> updateStacks(
-		@PathVariable("devExperienceId") Long devExperienceId,
-		@RequestBody StackAddRequestDTO request) {
-		List<Stack> updatedStacks = stackService.updateStacks(devExperienceId, request);
-		List<StackStatusResponseDTO> stackDTOs = StackConverter.toStatusResponseDTOList(updatedStacks);
-		StackListResponseDTO responseDTO = new StackListResponseDTO(stackDTOs);
-		return ApiResponse.of(SuccessCode.OK, responseDTO);
-	}
-
-	@Operation(summary = "기술스택 삭제")
-	@DeleteMapping("/{devExperienceId}")
-	public ApiResponse<Void> deleteStacksByDevExperienceId(
-		@PathVariable("devExperienceId") Long devExperienceId) {
-		stackService.deleteStacksByDevExperienceId(devExperienceId);
-		return ApiResponse.of(SuccessCode.OK);
 	}
 }

--- a/src/main/java/com/devpass/domain/stack/controller/StackController.java
+++ b/src/main/java/com/devpass/domain/stack/controller/StackController.java
@@ -1,5 +1,6 @@
 package com.devpass.domain.stack.controller;
 
+import com.devpass.domain.stack.dto.response.StackResponseDTO;
 import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,7 +9,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.devpass.domain.stack.converter.StackConverter;
 import com.devpass.domain.stack.dto.response.StackListResponseDTO;
-import com.devpass.domain.stack.dto.response.StackStatusResponseDTO;
 import com.devpass.domain.stack.entity.Stack;
 import com.devpass.domain.stack.service.StackService;
 import com.devpass.global.annotation.AuthUser;
@@ -32,7 +32,7 @@ public class StackController {
 	public ApiResponse<StackListResponseDTO> getStacks(
 		@AuthUser Long userId) {
 		List<Stack> stacks = stackService.getAllStacks(userId);
-		List<StackStatusResponseDTO> stackDTOs = StackConverter.toStatusResponseDTOList(stacks);
+		List<StackResponseDTO> stackDTOs = StackConverter.toResponseDTOList(stacks);
 		StackListResponseDTO responseDTO = new StackListResponseDTO(stackDTOs);
 		return ApiResponse.of(SuccessCode.OK, responseDTO);
 	}

--- a/src/main/java/com/devpass/domain/stack/converter/StackConverter.java
+++ b/src/main/java/com/devpass/domain/stack/converter/StackConverter.java
@@ -9,12 +9,12 @@ import java.util.stream.Collectors;
 public class StackConverter {
 
     public static StackStatusResponseDTO toStatusResponseDTO(Stack stack) {
-        return new StackStatusResponseDTO(stack.getName(), false);
+        return new StackStatusResponseDTO(stack.getId(), stack.getName());
     }
 
     public static List<StackStatusResponseDTO> toStatusResponseDTOList(List<Stack> stacks) {
         return stacks.stream()
-                .map(StackConverter::toStatusResponseDTO)
-                .collect(Collectors.toList());
+            .map(StackConverter::toStatusResponseDTO)
+            .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/devpass/domain/stack/converter/StackConverter.java
+++ b/src/main/java/com/devpass/domain/stack/converter/StackConverter.java
@@ -1,6 +1,6 @@
 package com.devpass.domain.stack.converter;
 
-import com.devpass.domain.stack.dto.response.StackStatusResponseDTO;
+import com.devpass.domain.stack.dto.response.StackResponseDTO;
 import com.devpass.domain.stack.entity.Stack;
 
 import java.util.List;
@@ -8,13 +8,13 @@ import java.util.stream.Collectors;
 
 public class StackConverter {
 
-    public static StackStatusResponseDTO toStatusResponseDTO(Stack stack) {
-        return new StackStatusResponseDTO(stack.getId(), stack.getName());
+    public static StackResponseDTO toResponseDTO(Stack stack) {
+        return new StackResponseDTO(stack.getId(), stack.getName());
     }
 
-    public static List<StackStatusResponseDTO> toStatusResponseDTOList(List<Stack> stacks) {
+    public static List<StackResponseDTO> toResponseDTOList(List<Stack> stacks) {
         return stacks.stream()
-            .map(StackConverter::toStatusResponseDTO)
+            .map(StackConverter::toResponseDTO)
             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/devpass/domain/stack/dto/request/StackAddRequestDTO.java
+++ b/src/main/java/com/devpass/domain/stack/dto/request/StackAddRequestDTO.java
@@ -12,6 +12,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class StackAddRequestDTO {
-    @Schema(description = "기술 스택", example = "[\"springBoot\", \"django\", \"docker\"]")
-    private List<String> stacks;
+    @Schema(description = "기술 스택")
+    private List<Long> stackIds;
 }

--- a/src/main/java/com/devpass/domain/stack/dto/response/StackListResponseDTO.java
+++ b/src/main/java/com/devpass/domain/stack/dto/response/StackListResponseDTO.java
@@ -9,5 +9,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class StackListResponseDTO {
-    private List<StackStatusResponseDTO> stacks;
+    private List<StackResponseDTO> stacks;
 }

--- a/src/main/java/com/devpass/domain/stack/dto/response/StackResponseDTO.java
+++ b/src/main/java/com/devpass/domain/stack/dto/response/StackResponseDTO.java
@@ -7,8 +7,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class StackStatusResponseDTO {
+public class StackResponseDTO {
     private Long id;
     private String name;
-    private String isRequired;
 }

--- a/src/main/java/com/devpass/domain/stack/dto/response/StackStatusResponseDTO.java
+++ b/src/main/java/com/devpass/domain/stack/dto/response/StackStatusResponseDTO.java
@@ -8,10 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class StackStatusResponseDTO {
-    private String stack;
-    private boolean isRequired;
-
-    public String getName() {
-        return this.stack;
-    }
+    private Long id;
+    private String name;
 }

--- a/src/main/java/com/devpass/domain/stack/entity/Stack.java
+++ b/src/main/java/com/devpass/domain/stack/entity/Stack.java
@@ -1,6 +1,5 @@
 package com.devpass.domain.stack.entity;
 
-import com.devpass.domain.devexperience.entity.DevExperience;
 import com.devpass.domain.devexpstack.entity.DevExpStack;
 import com.devpass.domain.projectstack.entity.ProjectStack;
 import jakarta.persistence.CascadeType;

--- a/src/main/java/com/devpass/domain/stack/entity/Stack.java
+++ b/src/main/java/com/devpass/domain/stack/entity/Stack.java
@@ -1,9 +1,11 @@
 package com.devpass.domain.stack.entity;
 
 import com.devpass.domain.devexperience.entity.DevExperience;
+import com.devpass.domain.devexpstack.entity.DevExpStack;
+import com.devpass.domain.projectstack.entity.ProjectStack;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import java.util.List;
 
 import com.devpass.domain.recruitment.entity.Recruitment;
@@ -38,18 +40,17 @@ public class Stack extends BaseEntity {
 	@ManyToMany(mappedBy = "stacks")
 	private List<Recruitment> recruitments;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "dev_experience_id", nullable = false)
-	private DevExperience devExperience;
+	@OneToMany(mappedBy = "stack", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	private List<ProjectStack> projectStacks;
+
+	@OneToMany(mappedBy = "stack", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	private List<DevExpStack> devExpStacks;
 
 	@Builder
-	public Stack(String name, DevExperience devExperience) {
+	public Stack(String name, List<ProjectStack> projectStacks, List<DevExpStack> devExpStacks) {
 		this.name = name;
-		this.devExperience = devExperience;
+		this.projectStacks = projectStacks;
+		this.devExpStacks = devExpStacks;
 
-	}
-
-	public String getName() {
-		return this.name;
 	}
 }

--- a/src/main/java/com/devpass/domain/stack/repository/StackRepository.java
+++ b/src/main/java/com/devpass/domain/stack/repository/StackRepository.java
@@ -7,5 +7,4 @@ import java.util.List;
 
 public interface StackRepository extends JpaRepository<Stack, Long> {
     Optional<Stack> findByName(String name);
-    List<Stack> findAllByDevExperience_Id(Long devExperienceId);
 }

--- a/src/main/java/com/devpass/domain/stack/service/StackService.java
+++ b/src/main/java/com/devpass/domain/stack/service/StackService.java
@@ -1,21 +1,14 @@
 package com.devpass.domain.stack.service;
 
-import java.util.ArrayList;
+import com.devpass.domain.devexpstack.repository.DevExpStackRepository;
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.devpass.domain.devexperience.entity.DevExperience;
 import com.devpass.domain.devexperience.repository.DevExperienceRepository;
-import com.devpass.domain.stack.converter.StackConverter;
-import com.devpass.domain.stack.dto.request.StackAddRequestDTO;
-import com.devpass.domain.stack.dto.response.StackStatusResponseDTO;
 import com.devpass.domain.stack.entity.Stack;
 import com.devpass.domain.stack.repository.StackRepository;
-import com.devpass.global.payload.apicode.ErrorStatus;
-import com.devpass.global.payload.error.exception.GeneralException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,64 +17,9 @@ import lombok.RequiredArgsConstructor;
 public class StackService {
 
 	private final StackRepository stackRepository;
-	private final DevExperienceRepository devExperienceRepository; // DevExperience 조회용
-
-	@Transactional
-	public List<Stack> addStacks(Long userId, Long devExperienceId, StackAddRequestDTO request) {
-		DevExperience devExperience = devExperienceRepository.findByIdAndUserId(devExperienceId, userId)
-			.orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND));
-
-		for (String stackName : request.getStacks()) {
-			Optional<Stack> existing = stackRepository.findByName(stackName);
-			if (existing.isEmpty()) {
-				Stack stack = Stack.builder()
-					.name(stackName)
-					.devExperience(devExperience)
-					.build();
-				stackRepository.save(stack);
-			}
-		}
-		return stackRepository.findAllByDevExperience_Id(devExperienceId);
-	}
 
 	@Transactional(readOnly = true)
 	public List<Stack> getAllStacks(Long userId) {
 		return stackRepository.findAll();
-	}
-
-	@Transactional(readOnly = true)
-	public List<StackStatusResponseDTO> getStacksByDevExperienceId(Long userId, Long devExperienceId) {
-		List<Stack> stacks = stackRepository.findAllByDevExperience_Id(devExperienceId);
-		return StackConverter.toStatusResponseDTOList(stacks);
-	}
-
-	@Transactional
-	public List<Stack> updateStacks(Long devExperienceId, StackAddRequestDTO request) {
-		DevExperience devExperience = devExperienceRepository.findById(devExperienceId)
-			.orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND));
-
-		// 기존 스택 삭제
-		List<Stack> existingStacks = stackRepository.findAllByDevExperience_Id(devExperienceId);
-		stackRepository.deleteAll(existingStacks);
-
-		// 새로운 스택 저장
-		List<Stack> newStacks = new ArrayList<>();
-		for (String stackName : request.getStacks()) {
-			Stack stack = Stack.builder()
-				.name(stackName)
-				.devExperience(devExperience)
-				.build();
-			newStacks.add(stackRepository.save(stack));
-		}
-		return newStacks;
-	}
-
-	@Transactional
-	public void deleteStacksByDevExperienceId(Long devExperienceId) {
-		List<Stack> stacks = stackRepository.findAllByDevExperience_Id(devExperienceId);
-		if (stacks.isEmpty()) {
-			throw new GeneralException(ErrorStatus.NOT_FOUND);
-		}
-		stackRepository.deleteAll(stacks);
 	}
 }


### PR DESCRIPTION
## 📖 개요
- 인턴십, 기술스택 도메인 API 리팩토링

## 💻 작업사항
- 인턴십
  - 인턴십 삭제 시 devExperienceId가 아닌 intershipId로 삭제되도록 변경
  - 개발 경험 별 인턴십 조회 API 구현
  - 인턴십 수정 시 생성한 유저만 수정 가능하도록 변경
- 기술 스택
  - 기존 DevExpStack은 프로젝트와 연결되어있어서, ProjectStack을 새로 만들고 DevExpStack에는 DevExperience를 연결
  - 기존 Stack 도메인에 구현되어있던 DevExp 의존 로직을 모두 DevExpStack으로 이동 및 로직 수정

## 💡 작성한 이슈 외에 작업한 사항
- dev-experiences로 되어있던 DevExperience DB 명을 dev_experiences로 언더바로 네이밍 통일

## ✔️ check list
- [x] 작성한 이슈의 내용을 전부 적용했나요?
- [x] 리뷰어를 등록했나요?
